### PR TITLE
Fix Chrome focusing the url bar on Windows/Linux

### DIFF
--- a/resources/js/Modal.jsx
+++ b/resources/js/Modal.jsx
@@ -14,7 +14,7 @@ export default function Modal() {
 	useHotkeys('meta+k', () => {
 		setOpen((prev) => !prev)
 		setContext('ACTIONS')
-	}, { enableOnFormTags: true })
+	}, { enableOnFormTags: true, preventDefault: true })
 
 	// prettier-ignore
 	useHotkeys('esc', () => {


### PR DESCRIPTION
Chrome and all Chromium browsers focus the URL bar when Ctrl + K is pressed on Windows/Linux
Prevent default is needed for the event handler to be called.